### PR TITLE
Raise MissingCountryException for easier catching by the caller

### DIFF
--- a/lib/iban-check/iban.rb
+++ b/lib/iban-check/iban.rb
@@ -1,4 +1,7 @@
 module Iban
+  class MissingCountryException < StandardError
+  end
+
   class IbanCheck
 
     BRANCH_WEIGHT       = [7,1,3,9,7,1,3]
@@ -85,7 +88,7 @@ module Iban
 
         result
       else
-        raise "No country specified"
+        raise MissingCountryException
       end
     end
 

--- a/spec/iban-check_spec.rb
+++ b/spec/iban-check_spec.rb
@@ -18,7 +18,7 @@ describe "IbanCheck" do
   end
 
   it "should raise error -- no country" do
-    lambda {Iban::IbanCheck.new(:iban => "27 1140 2004 0010 3002 0135 5387")}.should raise_error
+    lambda {Iban::IbanCheck.new(:iban => "27 1140 2004 0010 3002 0135 5387")}.should raise_error(Iban::MissingCountryException)
   end
 
   it "should recognize country" do


### PR DESCRIPTION
Hello!

I made this change to ensure it's easier for the calling library to intercept the exception (especially useful if two layers of callers are stacked up); in case you like it :)

Also I'd like your opinion on something for later on: if instead of raising an exception, the iban was just marked as invalid, like in ActiveRecord, maybe it would be nicer to use?

Let me know what you think.

I have another patch ongoing (a bin command to allow to check the validity of an IBAN from the command-line), will keep you posted.
