### PR TITLE
Fix for Ruby 1.9 compatibility: string[index] does not return an integer...

### DIFF
--- a/lib/iban-check/iban.rb
+++ b/lib/iban-check/iban.rb
@@ -36,7 +36,7 @@ module Iban
         result += item.to_i * BRANCH_WEIGHT_CHECK[index]
       end
 
-      if result.to_s[-1] == 48
+      if result.to_s[-1].ord == 48
         true
       else
         false


### PR DESCRIPTION
... but the character itself now. This commit supports both 1.8 and 1.9.

This fixes #5.

Not completely sure if some other parts need fixing or not, yet.
